### PR TITLE
📦 Add `django-debug-toolbar` & ✨ Implement Pagination on DRF

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -104,6 +104,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-debug-toolbar"
+version = "4.4.6"
+description = "A configurable set of panels that display various debug information about the current request/response."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_debug_toolbar-4.4.6-py3-none-any.whl", hash = "sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45"},
+    {file = "django_debug_toolbar-4.4.6.tar.gz", hash = "sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044"},
+]
+
+[package.dependencies]
+django = ">=4.2.9"
+sqlparse = ">=0.2"
+
+[[package]]
 name = "django-extensions"
 version = "3.2.3"
 description = "Extensions for Django"
@@ -341,4 +356,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "f1b95a3759ab57c8e3cc16c63ee003afc7cc4fcde75998ac95b5eed5601c0dc5"
+content-hash = "1a2dc4bb3f2b13d2e7ce33f0ca790bb99e878c3be4924917eefbf9815b5c4381"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ djangorestframework = "^3.15.2"
 django = "^5.1.1"
 python-decouple = "^3.8"
 django-extensions = "^3.2.3"
+django-debug-toolbar = "^4.4.6"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/setup/settings.py
+++ b/setup/settings.py
@@ -28,12 +28,16 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "rest_framework.authtoken",
+    "debug_toolbar",
     "django_extensions",
     "order.apps.OrderConfig",
     "product.apps.ProductConfig",
 ]
 
-REST_FRAMEWORK = {}
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "PAGE_SIZE": 10,
+}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -41,6 +45,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -122,3 +127,7 @@ STATICFILES_DIRS = [
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+INTERNAL_IPS = [
+    "127.0.0.1",
+]

--- a/setup/urls.py
+++ b/setup/urls.py
@@ -1,8 +1,10 @@
 from django.contrib import admin
 from django.urls import path, re_path, include
+import debug_toolbar
 
 
 urlpatterns = [
+    path("__debug__", include(debug_toolbar.urls)),
     path("admin/", admin.site.urls),
     re_path("bookstore/(?P<version>(v1|v2))/", include("order.urls")),
     re_path("bookstore/(?P<version>(v1|v2))/", include("product.urls")),


### PR DESCRIPTION
This PR introduces two key features to improve the development experience and API functionality:

1. **📦 Added `django-debug-toolbar`**  
   - Integrated `django-debug-toolbar` to aid in debugging and performance monitoring during local development.
   - The toolbar can be accessed via the `/__debug__/` endpoint, and `INTERNAL_IPS` has been configured accordingly.

2. **✨ Created Pagination for DRF**  
   - Implemented `LimitOffsetPagination` for the DRF with a default page size of 10 items, enhancing the API's usability for large datasets.

### Changes Summary:
- Added `django-debug-toolbar` to `pyproject.toml` and `settings.py`.
- Updated middleware to include `DebugToolbarMiddleware`.
- Added pagination settings to `REST_FRAMEWORK`.
- Adjusted `urls.py` to include the debug toolbar.

### Impact:
- **Developers**: Improved debugging and API inspection with `debug-toolbar`.
- **Users**: More efficient navigation through paginated results on the API.