### PR TITLE
🐳 Add Docker to initiate infrastructure

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12.1-slim as python-base
+
+ENV PYTHONUNBUFFERED=1 \
+  PYTHONDONTWRITEBYTECODE=1 \
+  \
+  PIP_NO_CACHE_DIR=off \
+  PIP_DISABLE_PIP_VERSION_CHECK=on \
+  PIP_DEFAULT_TIMEOUT=100 \
+  \
+  POETRY_HOME="/opt/poetry" \
+  POETRY_VIRTUALENVS_IN_PROJECT=true \
+  POETRY_NO_INTERACTION=1 \
+  \
+  PYSETUP_PATH="/opt/pysetup" \
+  VENV_PATH="/opt/pysetup/.venv"
+ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
+RUN apt-get update && apt-get install --no-install-recommends -y curl build-essential
+RUN pip install poetry
+RUN poetry init
+RUN apt-get update && apt-get -y install libpq-dev gcc && pip install psycopg2
+WORKDIR $PYSETUP_PATH
+COPY poetry.lock pyproject.toml ./
+RUN poetry install --no-dev
+RUN poetry install
+WORKDIR /app
+COPY . /app/
+EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
This PR introduces a `Dockerfile` to set up the initial infrastructure for the REST API with DRF. The Dockerfile is configured for a production-ready Python environment using **Poetry** for dependency management and **psycopg2** for PostgreSQL support.

#### 🔧 Key Features:
- Base image: `python:3.12.1-slim` for a lightweight and efficient setup.
- Configures Python environment with:
  - `PYTHONUNBUFFERED` and `PYTHONDONTWRITEBYTECODE` for optimized Python behavior.
  - Poetry for package and virtual environment management.
- Includes PostgreSQL dependencies (`libpq-dev` and `psycopg2`) for database integration.
- Exposes port `8000` for the application server.
- Sets the working directory to `/app` and includes all project files.
- Default command: `python manage.py runserver 0.0.0.0:8000`.

#### 🛠 Steps to Test:
1. Build the Docker image:
   ```bash
   docker build -t bookstore .
   ```
2. Run the container:
   ```bash
   docker run -p 8000:8000  bookstore
   ```
3. Access the API at `http://localhost:8000`.

---